### PR TITLE
perf: mover carregamento da fonte para _document.jsx

### DIFF
--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-import Head from 'next/head';
 import React, { useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { dark, light } from '../src/theme/colorThemes';
@@ -12,13 +11,6 @@ export default function App({ Component, pageProps }) {
 
   return (
     <>
-      <Head>
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
       <ThemeProvider theme={colorTheme}>
         <Component toggleTheme={toggleTheme} {...pageProps} />
       </ThemeProvider>

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -1,5 +1,7 @@
-import Document from 'next/document';
 import React from 'react';
+import Document, {
+  Html, Main, Head, NextScript,
+} from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
 
 export default class MyDocument extends Document {
@@ -26,5 +28,23 @@ export default class MyDocument extends Document {
     } finally {
       sheet.seal();
     }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Rubik:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
   }
 }


### PR DESCRIPTION
Na forma ensinada no bootcamp e que está sendo usada agora (no `_app.js`), as fontes são carregadas novamente cada vez que uma página nova é carregada. Se o cache for desabilitado, o cliente baixará a fonte ao acessar o `/`, `/sobre`, `/videos` etc.

O `_document` é carregado apenas 1 vez quando o cliente acessa o site, então esta mudança trará um pequeno ganho de performance.